### PR TITLE
SCH-005 Favor Pull over Push Payments

### DIFF
--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -297,10 +297,10 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     refund(execution);
   }
 
-  // This method is meant to be executed by the requestor, to get a refund on overdue executions.
-  // If it's called by anyone else, the caller will spend gas and get no benefit.
+  // This method is meant to be executed by the requestor to get a refund on overdue executions.
   function requestExecutionRefund(bytes32 id) external {
     require(getState(id) == ExecutionState.Overdue, 'Not overdue');
+    require(msg.sender == executions[id].requestor, 'Not authorized');
     Execution storage execution = executions[id];
     execution.state = ExecutionState.Refunded;
     emit ExecutionRefunded(id);

--- a/test/execution.test.js
+++ b/test/execution.test.js
@@ -146,7 +146,7 @@ contract('RIFScheduler - execution', (accounts) => {
       assert.strictEqual(await this.getState(txId), ExecutionState.ExecutionSuccessful, 'Execution failed')
     })
   })
-  describe('failing', () => {
+  describe('refund', () => {
     beforeEach(() => {
       this.refundTest = async (planId) => {
         const timestamp = await time.latest()
@@ -154,10 +154,12 @@ contract('RIFScheduler - execution', (accounts) => {
         const scheduleTimestamp = timestamp.add(toBN(ONE_DAY))
         const txId = await this.testScheduleWithValue(planId, incData, toBN(10), scheduleTimestamp)
         const requestorBalance = await web3.eth.getBalance(this.requestor)
-        // execute after window
-        const receipt = await this.executeWithTime(txId, timestamp.add(toBN(ONE_DAY).add(outsideWindow(planId))))
-        // this should reflect that it was late
-        expectEvent.notEmitted(receipt, 'Executed')
+        const executionTimestamp = timestamp.add(toBN(ONE_DAY).add(outsideWindow(planId)))
+        await time.increaseTo(executionTimestamp)
+        await time.advanceBlock()
+        const refundReceipt = await this.rifScheduler.requestExecutionRefund(txId)
+        expectEvent(refundReceipt, 'ExecutionRefunded')
+
         assert.strictEqual((await web3.eth.getBalance(this.requestor)) - requestorBalance, 0, 'Transaction value not refunded')
         assert.strictEqual(
           (await this.rifScheduler.remainingExecutions(this.requestor, toBN(planId))).toString(),
@@ -167,9 +169,24 @@ contract('RIFScheduler - execution', (accounts) => {
         assert.strictEqual(await this.getState(txId), ExecutionState.Refunded, 'Execution not failed')
       }
     })
+
+    it('should refund if it executes after timestamp + window', () => this.refundTest(0))
+
+    it('should refund if it executes after timestamp + window - rBTC', () => this.refundTest(1))
+
+    it('should not refund if not overdue', async () => {
+      const planId = 0
+      const timestamp = await time.latest()
+      const scheduleTimestamp = timestamp.add(toBN(ONE_DAY))
+      const txId = await this.testScheduleWithValue(planId, incData, toBN(10), scheduleTimestamp)
+      return expectRevert(this.rifScheduler.requestExecutionRefund(txId), 'Not overdue')
+    })
+  })
+
+  describe('failing', () => {
     it('cannot execute twice', async () => {
       const txId = await this.testExecutionWithValue(toBN(0), 0)
-      return expectRevert(this.rifScheduler.execute(txId), 'Already executed')
+      return expectRevert(this.rifScheduler.execute(txId), 'Not scheduled')
     })
 
     it('cannot execute before timestamp - window', async () => {
@@ -181,9 +198,15 @@ contract('RIFScheduler - execution', (accounts) => {
       return expectRevert(this.executeWithTime(txId, timestamp.add(toBN(ONE_DAY).sub(outsideWindow(0)))), 'Too soon')
     })
 
-    it('should refund if it executes after timestamp + window', () => this.refundTest(0))
-
-    it('should refund if it executes after timestamp + window - rBTC', () => this.refundTest(1))
+    it('cannot execute after timestamp + window', async () => {
+      const planId = 0
+      const timestamp = await time.latest()
+      // scheduled for tomorrow
+      const scheduleTimestamp = timestamp.add(toBN(ONE_DAY))
+      const txId = await this.testScheduleWithValue(planId, incData, toBN(10), scheduleTimestamp)
+      // execute after window
+      return expectRevert(this.executeWithTime(txId, timestamp.add(toBN(ONE_DAY).add(outsideWindow(planId)))), 'Not scheduled')
+    })
 
     it('should go from scheduled to Overdue when time passes', async () => {
       const timestamp = await time.latest()

--- a/test/scheduling.test.js
+++ b/test/scheduling.test.js
@@ -161,20 +161,19 @@ contract('RIFScheduler - scheduling', (accounts) => {
       assert.strictEqual(expectedRequestorBalance.toString(), finalRequestorBalance.toString(), 'Transaction value not refunded')
     })
 
-    it('should schedule, cancel execution and refund after execution window', async () => {
+    it('should schedule and not cancel execution after execution window', async () => {
       const scheduleTime = (await time.latest()).add(toBN(100))
       const timestampOutsideWindow = scheduleTime.add(outsideWindow(0))
       const txId = await this.testScheduleWithValue(0, toBN(1e15), scheduleTime)
       await time.increaseTo(timestampOutsideWindow)
       await time.advanceBlock()
-      const cancelTx = await this.rifScheduler.cancelScheduling(txId, { from: this.requestor })
-      expectEvent(cancelTx, 'ExecutionCancelled', { id: txId })
+      return expectRevert(this.rifScheduler.cancelScheduling(txId, { from: this.requestor }), 'Not scheduled')
     })
 
     it('should fail to cancel a cancelled execution', async () => {
       const txId = await this.scheduleOneValid(toBN(1e15))
       await this.rifScheduler.cancelScheduling(txId, { from: this.requestor })
-      return expectRevert(this.rifScheduler.cancelScheduling(txId, { from: this.requestor }), 'Transaction not scheduled')
+      return expectRevert(this.rifScheduler.cancelScheduling(txId, { from: this.requestor }), 'Not scheduled')
     })
 
     it('should fail to cancel transactions if not the requestor', async () => {


### PR DESCRIPTION
### Description

Its a best practice to use pull over push external calls. This means that instead of doing an external call to some address if a condition is met, instead require the address to call a smart contract method to execute that logic.
External calls can fail for multiple reasons, specially if the target address is a smart contract, so its preferred to let the target address call the smart contract

### Remediation
Instead of refunding the target address after a fail, save in a variable the value to be refunded to that address, and create a method for the address to get back the funds, instead of automatically send them

