### PR TITLE
SCH-009 Possible DoS with multicall method

### DIFF
--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -4,8 +4,12 @@ import '@rsksmart/erc677/contracts/IERC677.sol';
 import '@rsksmart/erc677/contracts/IERC677TransferReceiver.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/security/Pausable.sol';
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
+
+  using Strings for uint256;
+
   enum ExecutionState {
     Nonexistent,
     Scheduled,
@@ -350,27 +354,13 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     }
   }
 
-  function uintToBytes(uint v) pure internal returns (bytes32 ret) {
-      if (v == 0) {
-          ret = '0';
-      }
-      else {
-          while (v > 0) {
-              ret = bytes32(uint(ret) / (2 ** 8));
-              ret |= bytes32(((v % 10) + 48) * 2 ** (8 * 31));
-              v /= 10;
-          }
-      }
-      return ret;
-  }
-
   // This function enables multiple contact call, it revertIfFails is false the execution will continue even if a transaction reverted.
   // Otherwise this transaction will revert if any transaction reverts
   function multicall(bytes[] calldata data, bool revertIfFails) external whenNotPaused returns (bytes[] memory results) {
     results = new bytes[](data.length);
     for (uint256 i = 0; i < data.length; i++) {
       (bool success, bytes memory result) = address(this).delegatecall(data[i]);
-      require(success || !revertIfFails, string(abi.encodePacked('Transaction failed:', uintToBytes(i))));
+      require(success || !revertIfFails, string(abi.encodePacked('Transaction failed:', i.toString())));
       results[i] = result;
     }
     return results;

--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -4,10 +4,9 @@ import '@rsksmart/erc677/contracts/IERC677.sol';
 import '@rsksmart/erc677/contracts/IERC677TransferReceiver.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/security/Pausable.sol';
-import "@openzeppelin/contracts/utils/Strings.sol";
+import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
-
   using Strings for uint256;
 
   enum ExecutionState {

--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -350,11 +350,27 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     }
   }
 
-  function multicall(bytes[] calldata data) external whenNotPaused returns (bytes[] memory results) {
+  function uintToBytes(uint v) pure internal returns (bytes32 ret) {
+      if (v == 0) {
+          ret = '0';
+      }
+      else {
+          while (v > 0) {
+              ret = bytes32(uint(ret) / (2 ** 8));
+              ret |= bytes32(((v % 10) + 48) * 2 ** (8 * 31));
+              v /= 10;
+          }
+      }
+      return ret;
+  }
+
+  // This function enables multiple contact call, it revertIfFails is false the execution will continue even if a transaction reverted.
+  // Otherwise this transaction will revert if any transaction reverts
+  function multicall(bytes[] calldata data, bool revertIfFails) external whenNotPaused returns (bytes[] memory results) {
     results = new bytes[](data.length);
     for (uint256 i = 0; i < data.length; i++) {
       (bool success, bytes memory result) = address(this).delegatecall(data[i]);
-      require(success);
+      require(success || !revertIfFails, string(abi.encodePacked('Transaction failed:', uintToBytes(i))));
       results[i] = result;
     }
     return results;

--- a/test/multicall.test.js
+++ b/test/multicall.test.js
@@ -48,7 +48,7 @@ contract('RIFScheduler - multicall', (accounts) => {
     const scheduleTime = (await time.latest()).add(toBN(100))
     const to = this.counter.address
     const gas = toBN(await this.counter.inc.estimateGas())
-    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, gas, scheduleTime).encodeABI()
+    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, scheduleTime).encodeABI()
 
     const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
     const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist
@@ -64,7 +64,7 @@ contract('RIFScheduler - multicall', (accounts) => {
     const scheduleTime = (await time.latest()).add(toBN(100))
     const to = this.counter.address
     const gas = toBN(await this.counter.inc.estimateGas())
-    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, gas, scheduleTime).encodeABI()
+    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, scheduleTime).encodeABI()
 
     const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
     const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist

--- a/test/multicall.test.js
+++ b/test/multicall.test.js
@@ -28,7 +28,7 @@ contract('RIFScheduler - multicall', (accounts) => {
 
     const purchaseCall = this.rifScheduler.contract.methods.purchase(plan, 1).encodeABI()
     const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, scheduleTime).encodeABI()
-    const results = await this.rifScheduler.multicall([purchaseCall, schedule], { from: this.requestor })
+    const results = await this.rifScheduler.multicall([purchaseCall, schedule], true, { from: this.requestor })
     const executionId = getExecutionId(results)
     const actual = await this.rifScheduler.getExecutionById(executionId)
     const scheduled = await this.rifScheduler.remainingExecutions(this.requestor, plan)

--- a/test/multicall.test.js
+++ b/test/multicall.test.js
@@ -53,7 +53,10 @@ contract('RIFScheduler - multicall', (accounts) => {
     const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
     const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist
 
-    return expectRevert(this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState],true, { from: this.requestor }), "Transaction failed:1")
+    return expectRevert(
+      this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState], true, { from: this.requestor }),
+      'Transaction failed:1'
+    )
   })
 
   it('should not revert', async () => {
@@ -66,6 +69,6 @@ contract('RIFScheduler - multicall', (accounts) => {
     const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
     const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist
 
-    return this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState],false, { from: this.requestor })
+    return this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState], false, { from: this.requestor })
   })
 })

--- a/test/multicall.test.js
+++ b/test/multicall.test.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const { time } = require('@openzeppelin/test-helpers')
 const { toBN } = web3.utils
 const { plans, ExecutionState, setupContracts, getExecutionId, getMethodSig } = require('./common.js')
+const { expectRevert } = require('@openzeppelin/test-helpers')
 
 const incData = getMethodSig({ inputs: [], name: 'inc', type: 'function' })
 
@@ -40,5 +41,31 @@ contract('RIFScheduler - multicall', (accounts) => {
     assert.strictEqual(actual[5].toString(), '0')
     assert.strictEqual(actual[6].toString(), ExecutionState.Scheduled)
     assert.strictEqual(scheduled.toString(10), '0', `Shouldn't have any scheduling`)
+  })
+
+  it('should revert', async () => {
+    const plan = 0
+    const scheduleTime = (await time.latest()).add(toBN(100))
+    const to = this.counter.address
+    const gas = toBN(await this.counter.inc.estimateGas())
+    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, gas, scheduleTime).encodeABI()
+
+    const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
+    const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist
+
+    return expectRevert(this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState],true, { from: this.requestor }), "Transaction failed:1")
+  })
+
+  it('should not revert', async () => {
+    const plan = 0
+    const scheduleTime = (await time.latest()).add(toBN(100))
+    const to = this.counter.address
+    const gas = toBN(await this.counter.inc.estimateGas())
+    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, gas, scheduleTime).encodeABI()
+
+    const txID = '0x600b40d71ede22186cf277bdf9293563e9532729324708bcd50de97b01d7ffa8'
+    const getExecutionState = this.rifScheduler.contract.methods.getState(txID).encodeABI() // We don't care if doesn't exist
+
+    return this.rifScheduler.multicall([getExecutionState, schedule, getExecutionState],false, { from: this.requestor })
   })
 })


### PR DESCRIPTION
### Description
Since `multicall` runs a for with a call to another method, and may or may not revert depending on the outcome, this can cause a DoS in some conditions. It is not of high importance because you can always call `execute` instead. 

### Observations
The DoS may appear depending on how the service or the SDK call this method. If they collect scheduled transactions pending to be executed, and after `multicall` fail they keep trying the same transactions this has a DoS. 

### Remediation
`multicall` should be properly documented and used carefully. As a fallback to a failed `multicall`, `execute` should be used for each scheduled transaction.

`multicall` can also receive a parameter specifying if it should proceed to the next transaction in case of failure. If true, the failed transaction status should be updated (if failed, and not still to early or related validations) inside `multicall` since the value in `execute` was reverted
