### PR TITLE
SCH-007 Payee is paying for the scheduled transaction

### DIFF
--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -6,7 +6,15 @@ import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/security/Pausable.sol';
 
 contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
-  enum ExecutionState { Nonexistent, Scheduled, ExecutionSuccessful, ExecutionFailed, Overdue, Refunded, Cancelled }
+  enum ExecutionState {
+    Nonexistent,
+    Scheduled,
+    ExecutionSuccessful,
+    ExecutionFailed,
+    Overdue,
+    Refunded,
+    Cancelled
+  }
   // State transitions for scheduled executions:
   //   Initial state: Nonexistent
   //   Nonexistent -> Scheduled (requestor scheduled execution)
@@ -219,8 +227,10 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     uint256 totalValue;
     ids = new bytes32[](data.length);
     for (uint256 i = 0; i < data.length; i++) {
-      (uint256 plan, address to, bytes memory txData, uint256 timestamp, uint256 value) =
-        abi.decode(data[i], (uint256, address, bytes, uint256, uint256));
+      (uint256 plan, address to, bytes memory txData, uint256 timestamp, uint256 value) = abi.decode(
+        data[i],
+        (uint256, address, bytes, uint256, uint256)
+      );
       totalValue += value;
       ids[i] = _schedule(plan, to, txData, timestamp, value);
     }

--- a/contracts/RIFScheduler.sol
+++ b/contracts/RIFScheduler.sol
@@ -6,15 +6,7 @@ import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/security/Pausable.sol';
 
 contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
-  enum ExecutionState {
-    Nonexistent,
-    Scheduled,
-    ExecutionSuccessful,
-    ExecutionFailed,
-    Overdue,
-    Refunded,
-    Cancelled
-  }
+  enum ExecutionState { Nonexistent, Scheduled, ExecutionSuccessful, ExecutionFailed, Overdue, Refunded, Cancelled }
   // State transitions for scheduled executions:
   //   Initial state: Nonexistent
   //   Nonexistent -> Scheduled (requestor scheduled execution)
@@ -227,10 +219,8 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     uint256 totalValue;
     ids = new bytes32[](data.length);
     for (uint256 i = 0; i < data.length; i++) {
-      (uint256 plan, address to, bytes memory txData, uint256 timestamp, uint256 value) = abi.decode(
-        data[i],
-        (uint256, address, bytes, uint256, uint256)
-      );
+      (uint256 plan, address to, bytes memory txData, uint256 timestamp, uint256 value) =
+        abi.decode(data[i], (uint256, address, bytes, uint256, uint256));
       totalValue += value;
       ids[i] = _schedule(plan, to, txData, timestamp, value);
     }
@@ -325,9 +315,7 @@ contract RIFScheduler is IERC677TransferReceiver, ReentrancyGuard, Pausable {
     require(getState(id) == ExecutionState.Scheduled, 'Not scheduled');
     require((execution.timestamp - plan.window) < block.timestamp, 'Too soon');
 
-    (bool success, bytes memory result) = payable(execution.to).call{ gas: plan.gasLimit, value: execution.value }(
-      execution.data
-    );
+    (bool success, bytes memory result) = payable(execution.to).call{ gas: plan.gasLimit, value: execution.value }(execution.data);
 
     emit Executed(id, success, result);
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -17,7 +17,7 @@ module.exports = async (deployer, network, accounts) => {
 
   if (network === 'rskTestnet') {
     await RIFScheduler.deployed().then((rifScheduler) =>
-      rifScheduler.addPlan('10000000000000', '7200', '0x19f64674d8a5b4e652319f5e239efd3bc969a1fe')
+      rifScheduler.addPlan('10000000000000', '7200', '100000', '0x19f64674d8a5b4e652319f5e239efd3bc969a1fe')
     )
   }
 
@@ -25,7 +25,7 @@ module.exports = async (deployer, network, accounts) => {
     const devAccount = 'YOUR_ACCOUNT'
     await web3.eth.sendTransaction({ from: accounts[0], to: devAccount, value: '1000000000000000000' })
     await deployer.deploy(ERC677, devAccount, web3.utils.toBN('1000000000000000000000'), 'RIFOS', 'RIF')
-    await RIFScheduler.deployed().then((rifScheduler) => rifScheduler.addPlan('1000000000000000000', '300', ERC677.address))
+    await RIFScheduler.deployed().then((rifScheduler) => rifScheduler.addPlan('1000000000000000000', '300', '100000', ERC677.address))
   }
 
   if (network === 'develop' || network === 'ganache') {

--- a/test/common.js
+++ b/test/common.js
@@ -4,8 +4,9 @@ const ERC677 = artifacts.require('ERC677')
 const { toBN } = web3.utils
 
 const plans = [
-  { price: toBN(15), window: toBN(10000) },
-  { price: toBN(4), window: toBN(3000) },
+  { price: toBN(15), window: toBN(10000), gasLimit: toBN(200000) },
+  { price: toBN(4), window: toBN(3000), gasLimit: toBN(100000) },
+  { price: toBN(15), window: toBN(10000), gasLimit: toBN(10) }, //no gas plan use to make it fail
 ]
 
 exports.ExecutionState = {

--- a/test/multicall.test.js
+++ b/test/multicall.test.js
@@ -16,18 +16,17 @@ contract('RIFScheduler - multicall', (accounts) => {
 
     this.counter = await Counter.new()
 
-    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, this.token.address, { from: this.serviceProvider })
+    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, plans[0].gasLimit, this.token.address, { from: this.serviceProvider })
   })
 
   it('buy plan and schedule a new execution', async () => {
     const plan = 0
     const scheduleTime = (await time.latest()).add(toBN(100))
     const to = this.counter.address
-    const gas = toBN(await this.counter.inc.estimateGas())
     await this.token.approve(this.rifScheduler.address, toBN(1000), { from: this.requestor })
 
     const purchaseCall = this.rifScheduler.contract.methods.purchase(plan, 1).encodeABI()
-    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, gas, scheduleTime).encodeABI()
+    const schedule = this.rifScheduler.contract.methods.schedule(plan, to, incData, scheduleTime).encodeABI()
     const results = await this.rifScheduler.multicall([purchaseCall, schedule], { from: this.requestor })
     const executionId = getExecutionId(results)
     const actual = await this.rifScheduler.getExecutionById(executionId)
@@ -37,10 +36,9 @@ contract('RIFScheduler - multicall', (accounts) => {
     assert.strictEqual(actual[1].toString(), toBN(plan).toString(), 'Wrong plan')
     assert.strictEqual(actual[2], to, 'Wrong contract address')
     assert.strictEqual(actual[3], incData)
-    assert.strictEqual(actual[4].toString(), gas.toString())
-    assert.strictEqual(actual[5].toString(), scheduleTime.toString())
-    assert.strictEqual(actual[6].toString(), '0')
-    assert.strictEqual(actual[7].toString(), ExecutionState.Scheduled)
+    assert.strictEqual(actual[4].toString(), scheduleTime.toString())
+    assert.strictEqual(actual[5].toString(), '0')
+    assert.strictEqual(actual[6].toString(), ExecutionState.Scheduled)
     assert.strictEqual(scheduled.toString(10), '0', `Shouldn't have any scheduling`)
   })
 })

--- a/test/purchase.test.js
+++ b/test/purchase.test.js
@@ -13,10 +13,12 @@ contract('RIFScheduler - purchase', (accounts) => {
     this.rifScheduler = rifScheduler
     this.token2 = token2
 
-    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, this.token.address, { from: this.serviceProvider })
-    await this.rifScheduler.addPlan(plans[1].price, plans[1].window, constants.ZERO_ADDRESS, { from: this.serviceProvider })
-    await this.rifScheduler.addPlan(toBN(0), plans[1].window, this.token.address, { from: this.serviceProvider }) //free plan
-    await this.rifScheduler.addPlan(toBN(0), plans[1].window, constants.ZERO_ADDRESS, { from: this.serviceProvider }) //free plan
+    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, plans[0].gasLimit, this.token.address, { from: this.serviceProvider })
+    await this.rifScheduler.addPlan(plans[1].price, plans[1].window, plans[1].gasLimit, constants.ZERO_ADDRESS, {
+      from: this.serviceProvider,
+    })
+    await this.rifScheduler.addPlan(toBN(0), plans[1].window, plans[1].gasLimit, this.token.address, { from: this.serviceProvider }) //free plan
+    await this.rifScheduler.addPlan(toBN(0), plans[1].window, plans[1].gasLimit, constants.ZERO_ADDRESS, { from: this.serviceProvider }) //free plan
 
     this.testERC20Purchase = async (planId, value) => {
       const plan = await this.rifScheduler.plans(planId)

--- a/test/scheduling.test.js
+++ b/test/scheduling.test.js
@@ -25,14 +25,13 @@ contract('RIFScheduler - scheduling', (accounts) => {
     await this.token.approve(this.rifScheduler.address, toBN(1000), { from: this.requestor })
 
     this.counter = await Counter.new()
-    this.gas = toBN(await this.counter.inc.estimateGas())
 
-    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, this.token.address, { from: this.serviceProvider })
+    await this.rifScheduler.addPlan(plans[0].price, plans[0].window, plans[0].gasLimit, this.token.address, { from: this.serviceProvider })
 
     this.testScheduleWithValue = async (plan, value, timestamp) => {
       const to = this.counter.address
       await this.rifScheduler.purchase(plan, 1, { from: this.requestor })
-      const scheduleReceipt = await this.rifScheduler.schedule(plan, to, incData, this.gas, timestamp, { from: this.requestor, value })
+      const scheduleReceipt = await this.rifScheduler.schedule(plan, to, incData, timestamp, { from: this.requestor, value })
       const executionId = getExecutionId(scheduleReceipt)
       const actual = await this.rifScheduler.getExecutionById(executionId)
       const scheduled = await this.rifScheduler.remainingExecutions(this.requestor, plan)
@@ -41,10 +40,9 @@ contract('RIFScheduler - scheduling', (accounts) => {
       assert.strictEqual(actual[1].toString(), toBN(plan).toString(), 'Wrong plan')
       assert.strictEqual(actual[2], to, 'Wrong contract address')
       assert.strictEqual(actual[3], incData)
-      assert.strictEqual(actual[4].toString(), this.gas.toString())
-      assert.strictEqual(actual[5].toString(), timestamp.toString())
-      assert.strictEqual(actual[6].toString(), value.toString())
-      assert.strictEqual(actual[7].toString(), ExecutionState.Scheduled)
+      assert.strictEqual(actual[4].toString(), timestamp.toString())
+      assert.strictEqual(actual[5].toString(), value.toString())
+      assert.strictEqual(actual[6].toString(), ExecutionState.Scheduled)
 
       assert.strictEqual(scheduled.toString(10), '0', `Shouldn't have any scheduling`)
       return executionId
@@ -74,14 +72,14 @@ contract('RIFScheduler - scheduling', (accounts) => {
       '2',
       `Wrong initial balance after plan cancellation`
     )
-    const scheduleReceipt1 = await this.rifScheduler.schedule(plan, this.counter.address, incData, this.gas, timestamp, {
+    const scheduleReceipt1 = await this.rifScheduler.schedule(plan, this.counter.address, incData, timestamp, {
       from: this.requestor,
       value,
     })
     const executionId1 = getExecutionId(scheduleReceipt1)
     assert.strictEqual((await this.rifScheduler.remainingExecutions(this.requestor, plan)).toString(), '1', `Wrong balance - scheduled 1st`)
     await this.rifScheduler.removePlan(0, { from: this.serviceProvider })
-    const scheduleReceipt2 = await this.rifScheduler.schedule(plan, this.counter.address, incData, this.gas, timestamp.add(toBN(100)), {
+    const scheduleReceipt2 = await this.rifScheduler.schedule(plan, this.counter.address, incData, timestamp.add(toBN(100)), {
       from: this.requestor,
       value,
     })
@@ -89,8 +87,8 @@ contract('RIFScheduler - scheduling', (accounts) => {
     const executionId2 = getExecutionId(scheduleReceipt2)
     const actual1 = await this.rifScheduler.getExecutionById(executionId1)
     const actual2 = await this.rifScheduler.getExecutionById(executionId2)
-    assert.strictEqual(actual1[7].toString(), ExecutionState.Scheduled)
-    assert.strictEqual(actual2[7].toString(), ExecutionState.Scheduled)
+    assert.strictEqual(actual1[6].toString(), ExecutionState.Scheduled)
+    assert.strictEqual(actual2[6].toString(), ExecutionState.Scheduled)
   })
 
   it('schedule a new execution with value', async () => {
@@ -109,7 +107,7 @@ contract('RIFScheduler - scheduling', (accounts) => {
     await this.testScheduleWithValue(0, toBN(0), scheduleTime)
     // try to schedule another
     return expectRevert(
-      this.rifScheduler.schedule(0, this.counter.address, incData, toBN(await this.counter.inc.estimateGas()), scheduleTime.add(toBN(1)), {
+      this.rifScheduler.schedule(0, this.counter.address, incData, scheduleTime.add(toBN(1)), {
         from: this.requestor,
         value: toBN(0),
       }),
@@ -143,7 +141,7 @@ contract('RIFScheduler - scheduling', (accounts) => {
 
       //State should be Cancelled
       const scheduling = await this.rifScheduler.getExecutionById(txId)
-      assert.strictEqual(scheduling[7].toString(), ExecutionState.Cancelled, 'Not cancelled')
+      assert.strictEqual(scheduling[6].toString(), ExecutionState.Cancelled, 'Not cancelled')
 
       //Scheduling should be refunded
       assert.strictEqual((await this.rifScheduler.remainingExecutions(this.requestor, toBN(0))).toString(), '1', 'Schedule not refunded')
@@ -195,8 +193,8 @@ contract('RIFScheduler - scheduling', (accounts) => {
 
       this.encodeOneExecution = (execution) => {
         return web3.eth.abi.encodeParameters(
-          ['uint256', 'address', 'bytes', 'uint256', 'uint256', 'uint256'],
-          [execution.plan, execution.to, execution.data, execution.gas, execution.timestamp, execution.value]
+          ['uint256', 'address', 'bytes', 'uint256', 'uint256'],
+          [execution.plan, execution.to, execution.data, execution.timestamp, execution.value]
         )
       }
 
@@ -207,11 +205,10 @@ contract('RIFScheduler - scheduling', (accounts) => {
       this.getSampleExecutions = async (plan, quantity) => {
         const result = []
         const to = this.counter.address
-        const gas = toBN(await this.counter.inc.estimateGas())
         const timestampIncrement = toBN(100)
         const timestamp = (await time.latest()).add(toBN(100))
         const value = toBN(plans[plan].price)
-        const sampleExecution = { plan, to, data: incData, gas, timestamp, value }
+        const sampleExecution = { plan, to, data: incData, timestamp, value }
         for (let i = 0; i < quantity; i++) {
           result.push({ ...sampleExecution, timestamp: timestamp.add(timestampIncrement.mul(toBN(i))) })
         }
@@ -239,7 +236,6 @@ contract('RIFScheduler - scheduling', (accounts) => {
         assert.strictEqual(scheduledExecution.plan.toString(), requestedExecution.plan.toString(), 'Wrong plan')
         assert.strictEqual(scheduledExecution.to, requestedExecution.to, 'Wrong contract address')
         assert.strictEqual(scheduledExecution.data, requestedExecution.data)
-        assert.strictEqual(scheduledExecution.gas.toString(), requestedExecution.gas.toString())
         assert.strictEqual(scheduledExecution.timestamp.toString(), requestedExecution.timestamp.toString())
         assert.strictEqual(scheduledExecution.value.toString(), requestedExecution.value.toString())
         assert.strictEqual(scheduledExecution.state.toString(), ExecutionState.Scheduled)
@@ -267,7 +263,6 @@ contract('RIFScheduler - scheduling', (accounts) => {
         assert.strictEqual(scheduledExecution.plan.toString(), requestedExecution.plan.toString(), 'Wrong plan')
         assert.strictEqual(scheduledExecution.to, requestedExecution.to, 'Wrong contract address')
         assert.strictEqual(scheduledExecution.data, requestedExecution.data)
-        assert.strictEqual(scheduledExecution.gas.toString(), requestedExecution.gas.toString())
         assert.strictEqual(scheduledExecution.timestamp.toString(), requestedExecution.timestamp.toString())
         assert.strictEqual(scheduledExecution.value.toString(), requestedExecution.value.toString())
         assert.strictEqual(scheduledExecution.state.toString(), ExecutionState.Scheduled)


### PR DESCRIPTION
### Description
When a transaction is scheduled the amount of gas is specified by the user but there isn't any logic to get the value of the gas to execute the transaction. The payee will end up paying for the transaction gas. This can be used by an attacker to spend the payee funds.

### Observations
Whoever calls `execute` or `multicall` will end up paying the gas for the scheduled transactions so the methods should be restricted to the payee.

### Remediation
Make sure the payee cannot lose money. Request in advance for the user to pay for gas, it can be a "credit" until it runs out. You will need to feed the gasPrice when executing scheduled transactions.


### Implementation
We moved the gas limit from the execution (defined by the requestor) to the plan (defined by the service provider), to allow the service provider to limit the execution costs and consider them in plans price to mitigate the risks.

**The SP must consider this `gasLimit` in the plan pricing**